### PR TITLE
Update 2025 Ski Itinerary: Add Tesla pickup, remove unused accommodation, adjust trip duration

### DIFF
--- a/2025_ski_itinerary.md
+++ b/2025_ski_itinerary.md
@@ -6,8 +6,9 @@
 |-----------|------------------------------------|-----------------------------------------------|--------------------------------|----------------------------------------------------------|-----------------------------------|--------------------|-----------|
 | Dec 17    | **Travel to Sun Peaks**, BC        | Drive from Vancouver to Sun Peaks (4.5 hours) | -                              | -                                                        | **Fuel**: $150                    | Own Car            | **Yes**   |
 | Dec 18-20 | **Sun Peaks Resort**, BC           | Skiing with Tony (3 days)                     | **Sun Peaks Resort**           | Sun Peaks Lodge                                          | **Accom**: $500<br>**Food**: $200 | Own Car            | **Yes**   |
-| Dec 21-25 | **Revelstoke Mountain Resort**, BC | Skiing with Tony (5 days)                     | **Revelstoke Mountain Resort** | Revelstoke Lodge + Bear View Lodges + Swiss Chalet Motel | **Accom**: $500<br>**Food**: $200 | Own Car            | **Yes**   |
+| Dec 21-25 | **Revelstoke Mountain Resort**, BC | Skiing with Tony (4 days)                     | **Revelstoke Mountain Resort** | Revelstoke Lodge + Bear View Lodges | **Accom**: $500<br>**Food**: $200                      | Own Car            | **Yes**   |
 | Dec 26    | **Return to Vancouver**            | Drive back to Vancouver                       | -                              | -                                                        | **Fuel**: $150                    | Own Car            | **Yes**   |
+| Dec 27    | **Pick up Blue Model y from Elong Ma**| Profit                                     | -                              | -                                                        | **Electricity**: free             | My car             | **Yes**   |
 | Dec 27-31 | **Vancouver**, Canada              | Rest                                          | -                              | Family/Friends                                           | -                                 | No                 | **Yes**   |
 
 ---


### PR DESCRIPTION
This pull request updates the 2025 ski itinerary with the following changes:
- Added a new event: "Pick up Blue Model y from Elong Ma" on Dec 27
- Removed "Swiss Chalet Motel" from the Revelstoke accommodation list
- Corrected the skiing duration at Revelstoke from 5 to 4 days, adjusting the total trip from 8 to 7 days
- Minor formatting improvements for consistency